### PR TITLE
Update to dropwizard-metrics-influxdb 1.1.8 for cleaned up deps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,4 +5,4 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [metrics-clojure "2.7.0"]
-                 [com.izettle/dropwizard-metrics-influxdb "1.1.6"]])
+                 [com.izettle/dropwizard-metrics-influxdb "1.1.8"]])


### PR DESCRIPTION
This version of iZettle dropwizard-metrics-influxdb removes the dependency on dropwizard-core, greatly reducing the set of transitive dependencies pulled in by this library.